### PR TITLE
Made sure the touch event is propagated when not clicking on the clea…

### DIFF
--- a/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
+++ b/library/src/main/java/com/rengwuxian/materialedittext/MaterialEditText.java
@@ -1469,8 +1469,9 @@ public class MaterialEditText extends AppCompatEditText {
           if (insideClearButton(event)) {
             clearButtonTouched = true;
             clearButtonClicking = true;
+            return true;
           }
-          return true;
+          break;
         case MotionEvent.ACTION_MOVE:
           if (clearButtonClicking && !insideClearButton(event)) {
             clearButtonClicking = false;


### PR DESCRIPTION
Found a problem with the touch behaviour. When navigating from an activity with a focused materialedittextfield to another activity and then going back I could not tap the edittext to bring up the keyboard anymore.

I added some test code to the sample app in this other branch: https://github.com/mickejohansson/MaterialEditText/tree/fix_focus_bug_after_back
To reproduce:
- Launch sample app
- Scroll to the bottom
- Focus the textfield with the hint "test"
- Press the button labeled "Click me"
- Go back.
- Try to bring up the keyboard by tapping the edittext. This did not work.
